### PR TITLE
Fixed bugs in mobile view

### DIFF
--- a/src/components/Event/EventSponsers/EventSponsers.css
+++ b/src/components/Event/EventSponsers/EventSponsers.css
@@ -91,8 +91,13 @@
 }
 
 @media (max-width: 900px) {
+    .sponsors-container h3{
+        margin-right: 0 ;
+    }
     .sponsors-container {
-        margin-left: 10px;
+        margin: 100px 0;
+        justify-content: center;
+        align-items: center;
     }
     .sponsors-col {
         height: 130px;

--- a/src/pages/event/index.css
+++ b/src/pages/event/index.css
@@ -55,5 +55,6 @@
     .event-main{
         margin-left: 0;
         border-left: hidden;
+        padding-bottom: 0;
     }
 }


### PR DESCRIPTION
Even though flex was applied, there was a padding-right: 100px in global which applied to mobile view also.
When I made it 0 for screen size<900px, it was fixed, 
Just to make sure, I have added the flexbox properties again, in case, something else interferes 